### PR TITLE
Rename [project] to [workspace] in pixi.toml

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -1,4 +1,4 @@
-[project]
+[workspace]
 name = "ReLERNN"
 version = "0.2.0"
 description = "Recombination Landscape Estimation using Recurrent Neural Networks"


### PR DESCRIPTION
Got a warning saying " WARN Encountered 1 warning while parsing the manifest:
  ⚠ The `project` field is deprecated. Use `workspace` instead."